### PR TITLE
Add Puppet/PE requirements to module metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,6 +8,16 @@
   "project_page": "https://github.com/Andulla/vsphere_conf",
   "issues_url": "https://github.com/Andulla/vsphere_conf/issues",
   "tags": ["VMware", "vSphere","vCenter"],
+  "requirements": [
+    {
+      "name": "pe",
+      "version_requirement": ">=2015.2.x"
+    },
+    {
+      "name": "puppet",
+      "version_requirement": ">4.0.0 < 5.0.0"
+    }
+  ],
   "operatingsystem_support": [
     {
     "operatingsystem":"RedHat",


### PR DESCRIPTION
Mostly to clear quality score on the Forge.
I know vsphere requires PE, but the module does compile on Puppet 4.x, so I've left that in there.
